### PR TITLE
Default to PLATFORM_NAME=desktop for any non-DGX UID on x86_64

### DIFF
--- a/scripts/custom/deploy_bag_data_extraction.sh
+++ b/scripts/custom/deploy_bag_data_extraction.sh
@@ -8,14 +8,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-    PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_data_saver.sh
+++ b/scripts/custom/deploy_data_saver.sh
@@ -8,14 +8,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-    PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_data_validation.sh
+++ b/scripts/custom/deploy_data_validation.sh
@@ -8,14 +8,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-    PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_ros2_humble.sh
+++ b/scripts/custom/deploy_ros2_humble.sh
@@ -8,14 +8,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_ros2_humble_display.sh
+++ b/scripts/custom/deploy_ros2_humble_display.sh
@@ -10,14 +10,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 || $USER_ID == 1000 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_ros2_humble_display_kuka.sh
+++ b/scripts/custom/deploy_ros2_humble_display_kuka.sh
@@ -10,14 +10,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_rosbag_recorder.sh
+++ b/scripts/custom/deploy_rosbag_recorder.sh
@@ -8,14 +8,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"

--- a/scripts/custom/deploy_rqt_gui.sh
+++ b/scripts/custom/deploy_rqt_gui.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 xhost +
@@ -11,14 +10,11 @@ DOCKER_USER="admin"
 if [[ $PLATFORM == "aarch64" ]]; then
     PLATFORM_NAME="jetson"
 elif [[ $PLATFORM == "x86_64" ]]; then
-    if [[ $USER_ID == 1001 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
 else
     echo "Unsupported platform: $PLATFORM"


### PR DESCRIPTION
## Related

Tracks BAL-ORX/orx_middleware#73 (issues live on GitLab; this repo is github-only for now).

## Problem

8 x86_64-aware deploy scripts under `scripts/custom/` gate `PLATFORM_NAME` on a hard-coded UID allow-list (`1001` → desktop, `1003` → dgx, everything else → `"Unsupported user id"` + `exit 1`). Any dev laptop whose login UID isn't in that list (e.g. `1000`) hits the exit immediately and can't run any of them.

## Fix

Keep `UID == 1003` → dgx (still has to flip `DOCKER_USER=orx_user`); everything else on x86_64 defaults to `desktop`:

```diff
-    if [[ $USER_ID == 1001 ]]; then
-        PLATFORM_NAME="desktop"
-    elif [[ $USER_ID == 1003 ]]; then
+    if [[ $USER_ID == 1003 ]]; then
         PLATFORM_NAME="dgx"
         DOCKER_USER="orx_user"
     else
-        echo "Unsupported user id: $USER_ID"
-        exit 1
+        PLATFORM_NAME="desktop"
     fi
```

Scripts touched (all the same 5-line replacement):

- `deploy_bag_data_extraction.sh`
- `deploy_data_saver.sh`
- `deploy_data_validation.sh`
- `deploy_ros2_humble.sh`
- `deploy_ros2_humble_display.sh`
- `deploy_ros2_humble_display_kuka.sh`
- `deploy_rosbag_recorder.sh`
- `deploy_rqt_gui.sh`

## Rationale

UID matters as a discriminator between the desktop and dgx personalities; it doesn't actually have to be one specific desktop UID. Anyone on dgx must run as UID 1003 anyway (per the system's account setup), so the dgx branch stays a strict equality check. The desktop case is the catch-all for any human running this on a regular workstation.

## Acceptance

- [x] All 8 scripts accept any non-1003 UID on x86_64 and default to `PLATFORM_NAME=desktop`.
- [x] dgx behavior (`UID == 1003` → `PLATFORM_NAME=dgx`, `DOCKER_USER=orx_user`) preserved.
- [x] Jetson (aarch64) branch untouched.

<!-- gk-ai-analysis-start:6f4b68f8389297ccab0937f7ba6f7f33b49f887e -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiU2ltcGxpZnkgeDg2XzY0IHBsYXRmb3JtIGRldGVjdGlvbiBpbiBjdXN0b20gZGVwbG95IHNjcmlwdHMgdG8gZGVmYXVsdCB0byAnZGVza3RvcCcgZm9yIGFueSBub24tREdYIFVJRC4iLCJrZXlJbnNpZ2h0cyI6W3sidGl0bGUiOiJEZWZhdWx0IHBsYXRmb3JtIG9uIHg4Nl82NCBjaGFuZ2VkIHRvICdkZXNrdG9wJyIsImRlc2NyaXB0aW9uIjoiVGhlIGxvZ2ljIG5vdyBhc3NpZ25zICdkZXNrdG9wJyB0byBgUExBVEZPUk1fTkFNRWAgZm9yIGFsbCBVSURzIGV4Y2VwdCAxMDAzIG9uIHg4Nl82NCBhcmNoaXRlY3R1cmVzLCByZW1vdmluZyB0aGUgc3RyaWN0IGNoZWNrIGZvciBVSUQgMTAwMC8xMDAxIGFuZCB0aGUgZmF0YWwgZXJyb3IgZXhpdCBmb3IgdW5zdXBwb3J0ZWQgVUlEcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic2NyaXB0cy9jdXN0b20vZGVwbG95X2JhZ19kYXRhX2V4dHJhY3Rpb24uc2giLCJsaW5lU3RhcnQiOjExfV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:6f4b68f8389297ccab0937f7ba6f7f33b49f887e -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/BAL-ORX/isaac_ros_common/pull/3?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->